### PR TITLE
use non-adjusted p-values

### DIFF
--- a/src/task/process_dataset/run_limma/script.R
+++ b/src/task/process_dataset/run_limma/script.R
@@ -107,10 +107,9 @@ de_df2 <- de_df %>%
     # readjust p-values for multiple testing
     adj.P.Value = p.adjust(P.Value, method = "BH"),
     # compute sign log10 p-values
-    sign_log10_nonadj_pval = sign(logFC) * -log10(ifelse(P.Value == 0, .Machine$double.eps, P.Value)),
-    sign_log10_pval = sign(logFC) * -log10(ifelse(adj.P.Value == 0, .Machine$double.eps, adj.P.Value)),
+    sign_log10_pval = sign(logFC) * -log10(ifelse(P.Value == 0, .Machine$double.eps, P.Value)),
+    sign_log10_adj_pval = sign(logFC) * -log10(ifelse(adj.P.Value == 0, .Machine$double.eps, adj.P.Value)),
     is_de = P.Value < par$de_sig_cutoff,
-    is_de_adj = adj.P.Val < par$de_sig_cutoff
   ) %>%
   as_tibble()
 
@@ -118,7 +117,7 @@ rownames(new_obs) <- paste0(new_obs$cell_type, ", ", new_obs$sm_name)
 new_var <- data.frame(row.names = levels(de_df2$gene))
 
 # create layers from de_df
-layer_names <- c("is_de", "is_de_adj", "logFC", "P.Value", "adj.P.Value", "sign_log10_pval", "sign_log10_nonadj_pval")
+layer_names <- c("is_de", "is_de_adj", "logFC", "P.Value", "adj.P.Value", "sign_log10_adj_pval", "sign_log10_pval")
 layers <- map(setNames(layer_names, layer_names), function(layer_name) {
   de_df2 %>%
     select(gene, row_i, !!layer_name) %>%


### PR DESCRIPTION
## Describe your changes

After recent evaluation of representations, we found out that non-adjusted p-values better preserve the magnitude of the change, especially for high p-values

## Checklist before requesting a review
- [x] I have performed a self-review of my code

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality (new method, new metric, ...)
  - [ ] Major changes
  - [ x] Minor changes
  - [ ] Bug fixes

- [ ] Proposed changes are described in the CHANGELOG.md

- [ ] CI Tests succeed and look good!
